### PR TITLE
Change mime-types.conf to mime.types in static sites quickstart

### DIFF
--- a/docs/quickstarts/static-sites.md
+++ b/docs/quickstarts/static-sites.md
@@ -36,7 +36,7 @@ http {
 }
 ```
 
-```bash title="/mime-types.conf" showLineNumbers
+```bash title="/mime.types" showLineNumbers
 types {
   text/html html htm shtml;
   text/css css;


### PR DESCRIPTION
- tried to create a static site in fl0
- got and error saying `mime.types` not found
- renamed `mine-types.conf` to `mime.types` and it all worked