### PR TITLE
Added extra documentation to mention alignment of port variables

### DIFF
--- a/docs/builds/dockerfile/python.md
+++ b/docs/builds/dockerfile/python.md
@@ -8,6 +8,7 @@ Below is an example Dockerfile based off a Python application using FastAPI and 
 
 :::info
 Keep in mind you'll need to alter this to work with your specific file structure.
+Exposed Port must match PORT variable defined in enviroment varibles, here it's 8080.
 :::
 
 ```bash title="/Dockerfile"
@@ -23,5 +24,5 @@ COPY --from=requirements-stage /tmp/requirements.txt /code/requirements.txt
 RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
 COPY ./app /code/app
 
-CMD ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "app.main:app", "--proxy-headers", "--host", "0.0.0.0", "--port", "8080"]
 ```


### PR DESCRIPTION
By default it's better to have port 8080, 80 gives errors, would help beginners to align exposed ports 